### PR TITLE
fix _count being NaN in ObjectList

### DIFF
--- a/src/util/objectList.ts
+++ b/src/util/objectList.ts
@@ -8,7 +8,7 @@ class ObjectList<T>
 
 	public unsorted:boolean;
 	private dirty:boolean;
-	private _count:number;
+	private _count:number = 0;
 	public get count():number { return this._count; }
 
 	/**


### PR DESCRIPTION
I noticed `Scene.firstInGroup(groupName)` returning null when I didn't expect it to.

It turned out that the group `ObjectList`'s `_count` property was NaN and never initialized.

This change just defaults `_count` to 0--which fixes the bug.