### PR TITLE
fix bug in Scene.firstColliderInTag

### DIFF
--- a/src/scene.ts
+++ b/src/scene.ts
@@ -24,7 +24,7 @@ class Scene
 	 */
 	public groups:{[id:string]:ObjectList<Entity>} = {};
 	
-	private colliders:any = {};
+	private colliders:{[key:string]:Collider[]} = {};
 	private cache:any = {};
 	
 	constructor()
@@ -332,7 +332,7 @@ class Scene
 	public firstColliderInTag(tag:string):Collider
 	{
 		if (this.colliders[tag] != undefined && this.colliders[tag].length > 0)
-			return this.colliders[tag];
+			return this.colliders[tag][0];
 		return null;
 	}
 


### PR DESCRIPTION
In `Scene`, `this.colliders` had type "`any`."

Adding a type so that `this.colliders` is instead a map of `string:Collider[]` revealed a bug in `firstColliderInTag`, which was returning a list of `Collider`s, instead of the first one. This change also fixes that and returns the first element in the list.