### PR TITLE
copy an incoming position vector in Graphic's constructor

### DIFF
--- a/src/components/sprites/graphic.ts
+++ b/src/components/sprites/graphic.ts
@@ -26,7 +26,7 @@ class Graphic extends Component
 		}
 
 		if (position)
-			this.position = position;
+			this.position.copy(position);
 	}
 
 	public center():void


### PR DESCRIPTION
With this bug, `new Graphic(Vector.temp0.set(0, 0))` would mean trouble.

Make sure to copy an incoming position arg in the `Graphic` constructor.